### PR TITLE
Add option for route formatter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,9 @@ edition = "2018"
 [dependencies]
 actix-web = "1.0.9"
 futures = "0.1.25"
-opentelemetry = "0.1.3"
+opentelemetry = "0.1.4"
+regex = "1.3.1"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 actix-rt = "0.2.6"

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -22,7 +22,7 @@ fn main() -> std::io::Result<()> {
     init_tracer();
     HttpServer::new(|| {
         App::new()
-            .wrap(RequestTracing::new(false))
+            .wrap(RequestTracing::default())
             .service(web::resource("/index.html").to(|| "Hello world!"))
             .service(web::resource("/").to(index))
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,5 +55,10 @@
 
 mod client;
 mod middleware;
+mod route_formatter;
 
-pub use {client::with_tracing, middleware::RequestTracing};
+pub use {
+    client::with_tracing,
+    middleware::RequestTracing,
+    route_formatter::{RouteFormatter, UuidWildcardFormatter},
+};

--- a/src/route_formatter.rs
+++ b/src/route_formatter.rs
@@ -1,0 +1,33 @@
+//! # Route Formatter
+//!
+//! Format routes from paths.
+use regex::Regex;
+
+/// Interface for formatting routes from paths
+pub trait RouteFormatter {
+    /// Function from path to route.
+    /// e.g. /users/123 -> /users/:id
+    fn format(&self, uri: &str) -> String;
+}
+
+/// UUID wildcard formatter replaces UUIDs with asterisks.
+#[derive(Clone, Debug, Default)]
+pub struct UuidWildcardFormatter {}
+
+impl UuidWildcardFormatter {
+    /// Create a new `UuidWildcardFormatter`
+    pub fn new() -> Self {
+        UuidWildcardFormatter {}
+    }
+}
+
+impl RouteFormatter for UuidWildcardFormatter {
+    /// Function from path to route
+    /// e.g. /users/4f5accfe-45d2-43b1-bf10-fdad708732a8 -> /users/*
+    fn format(&self, uri: &str) -> String {
+        lazy_static::lazy_static! {
+            static ref UUID: Regex = Regex::new(r"[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}").unwrap();
+        }
+        UUID.replace_all(uri, "*").into_owned()
+    }
+}


### PR DESCRIPTION
Add route formatter options.

`UuidWildcardFormatter` formats paths from `/users/7bae19f5-8db8-49e6-b3a7-1f3f4ce9a861` -> `/users/*`

