### PR TITLE
Make client span name match otel spec

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -47,7 +47,7 @@ where
     let tracer = opentelemetry::global::trace_provider().get_tracer("actix-client");
     let injector = opentelemetry::api::HttpB3Propagator::new(false);
     let parent = tracer.get_active_span().get_context();
-    let mut span = tracer.start(&request.get_uri().to_string(), Some(parent));
+    let mut span = tracer.start(request.get_uri().path(), Some(parent));
     span.set_attribute(KeyValue::new(SPAN_KIND_ATTRIBUTE, "client"));
     span.set_attribute(KeyValue::new(COMPONENT_ATTRIBUTE, "http"));
     span.set_attribute(KeyValue::new(


### PR DESCRIPTION
From the [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-http.md#name):

> Given an RFC 3986 compliant URI of the form scheme:[//host[:port]]path[?query][#fragment], the span name of the span SHOULD be set to the URI path value, unless another value that represents the identity of the request and has a lower cardinality can be identified (e.g. the route for server spans; see below).