### PR TITLE
Simplify client tracing and use global propagator API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,13 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
+actix-http = "1.0"
 actix-web = "2.0"
 futures = "0.3"
+lazy_static = "1.4"
 opentelemetry = "0.7"
 regex = "1.3"
-lazy_static = "1.4"
+serde = "1.0"
 
 [dev-dependencies]
 actix-rt = "1.0"

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,15 +1,16 @@
 use actix_web::client;
+use actix_web_opentelemetry::ClientExt;
 use opentelemetry::{api::KeyValue, global, sdk};
 use std::io;
 use std::sync::Arc;
 
 async fn execute_request(client: client::Client) -> Result<String, io::Error> {
-    let mut response = actix_web_opentelemetry::with_tracing(
-        client.get("http://localhost:8080/users/103240ba-3d8d-4695-a176-e19cbc627483?a=1"),
-        |request| request.send(),
-    )
-    .await
-    .map_err(|err| io::Error::new(io::ErrorKind::Other, err.to_string()))?;
+    let mut response = client
+        .get("http://localhost:8080/users/103240ba-3d8d-4695-a176-e19cbc627483?a=1")
+        .trace_request()
+        .send()
+        .await
+        .map_err(|err| io::Error::new(io::ErrorKind::Other, err.to_string()))?;
 
     let bytes = response
         .body()

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,11 +1,18 @@
-use actix_web::client::{ClientRequest, ClientResponse};
-use actix_web::http::{HeaderName, HeaderValue};
-use futures::{future::TryFutureExt, Future};
+use actix_http::{encoding::Decoder, Error, Payload, PayloadStream};
+use actix_web::{
+    body::Body,
+    client::{ClientRequest, ClientResponse, SendRequestError},
+    http::{HeaderName, HeaderValue},
+    web::Bytes,
+};
+use futures::{future::TryFutureExt, Future, Stream};
 use opentelemetry::api::{
     Carrier, Context, FutureExt, HttpTextFormat, KeyValue, SpanKind, StatusCode, TraceContextExt,
     Tracer, Value,
 };
 use opentelemetry::global;
+use serde::Serialize;
+use std::fmt;
 use std::str::FromStr;
 
 static HTTP_METHOD_ATTRIBUTE: &str = "http.method";
@@ -17,7 +24,7 @@ static HTTP_FLAVOR_ATTRIBUTE: &str = "http.flavor";
 /// Trace an `actix_web::client::Client` request.
 ///
 /// Example:
-/// ```rust,no_run
+/// ```no_run
 /// use actix_web::client;
 /// use futures::Future;
 ///
@@ -34,6 +41,7 @@ static HTTP_FLAVOR_ATTRIBUTE: &str = "http.flavor";
 ///     })
 /// }
 /// ```
+#[deprecated(since = "0.5.0", note = "Please use ClientExt::trace_request instead")]
 pub async fn with_tracing<F, R, RE, S>(
     mut request: ClientRequest,
     f: F,
@@ -41,7 +49,7 @@ pub async fn with_tracing<F, R, RE, S>(
 where
     F: FnOnce(ClientRequest) -> R,
     R: Future<Output = Result<ClientResponse<S>, RE>>,
-    RE: std::fmt::Debug,
+    RE: fmt::Debug,
 {
     let tracer = global::tracer("actix-client");
     let injector = opentelemetry::api::B3Propagator::default();
@@ -97,6 +105,188 @@ where
             span.end();
         })
         .await
+}
+
+/// A wrapper for the actix-web [`ClientRequest`].
+///
+/// [`ClientRequest`]: https://docs.rs/actix-web/2.0.0/actix_web/client/struct.ClientRequest.html
+#[derive(Debug)]
+pub struct InstrumentedClientRequest {
+    cx: Context,
+    request: ClientRequest,
+}
+
+/// OpenTelemetry extensions for actix-web's [`Client`].
+///
+/// [`Client`]: https://docs.rs/actix-web/2.0.0/actix_web/client/struct.Client.html
+pub trait ClientExt {
+    /// Trace an `actix_web::client::Client` request using the current context.
+    ///
+    /// Example:
+    /// ```no_run
+    /// use actix_web::client;
+    /// use actix_web_opentelemetry::ClientExt;
+    ///
+    /// async fn execute_request(client: &client::Client) -> Result<(), client::SendRequestError> {
+    ///     let res = client.get("http://localhost:8080")
+    ///         .trace_request()
+    ///         .send()
+    ///         .await?;
+    ///
+    ///     println!("Response: {:?}", res);
+    ///     Ok(())
+    /// }
+    /// ```
+    fn trace_request(self) -> InstrumentedClientRequest
+    where
+        Self: Sized,
+    {
+        self.trace_request_with_context(Context::current())
+    }
+
+    /// Trace an `actix_web::client::Client` request using the given span context.
+    ///
+    /// Example:
+    /// ```no_run
+    /// use actix_web::client;
+    /// use actix_web_opentelemetry::ClientExt;
+    /// use opentelemetry::api::Context;
+    ///
+    /// async fn execute_request(client: &client::Client) -> Result<(), client::SendRequestError> {
+    ///     let res = client.get("http://localhost:8080")
+    ///         .trace_request_with_context(Context::current())
+    ///         .send()
+    ///         .await?;
+    ///
+    ///     println!("Response: {:?}", res);
+    ///     Ok(())
+    /// }
+    /// ```
+    fn trace_request_with_context(self, cx: Context) -> InstrumentedClientRequest;
+}
+
+impl ClientExt for ClientRequest {
+    fn trace_request_with_context(self, cx: Context) -> InstrumentedClientRequest {
+        InstrumentedClientRequest { cx, request: self }
+    }
+}
+
+type AwcResult = Result<ClientResponse<Decoder<Payload<PayloadStream>>>, SendRequestError>;
+
+impl InstrumentedClientRequest {
+    /// Generate an awc `ClientResponse` from a traced request with an empty body.
+    ///
+    /// [`ClientResponse`]: https://docs.rs/actix-web/2.0.0/actix_web/client/struct.ClientResponse.html
+    pub async fn send(self) -> AwcResult {
+        self.trace_request(|request| request.send()).await
+    }
+
+    /// Generate an awc `ClientResponse` from a traced request with the given body.
+    ///
+    /// [`ClientResponse`]: https://docs.rs/actix-web/2.0.0/actix_web/client/struct.ClientResponse.html
+    pub async fn send_body<B>(self, body: B) -> AwcResult
+    where
+        B: Into<Body>,
+    {
+        self.trace_request(|request| request.send_body(body)).await
+    }
+
+    /// Generate an awc `ClientResponse` from a traced request with the given form
+    /// body.
+    ///
+    /// [`ClientResponse`]: https://docs.rs/actix-web/2.0.0/actix_web/client/struct.ClientResponse.html
+    pub async fn send_form<T: Serialize>(self, value: &T) -> AwcResult {
+        self.trace_request(|request| request.send_form(value)).await
+    }
+
+    /// Generate an awc `ClientResponse` from a traced request with the given JSON
+    /// body.
+    ///
+    /// [`ClientResponse`]: https://docs.rs/actix-web/2.0.0/actix_web/client/struct.ClientResponse.html
+    pub async fn send_json<T: Serialize>(self, value: &T) -> AwcResult {
+        self.trace_request(|request| request.send_json(value)).await
+    }
+
+    /// Generate an awc `ClientResponse` from a traced request with the given stream
+    /// body.
+    ///
+    /// [`ClientResponse`]: https://docs.rs/actix-web/2.0.0/actix_web/client/struct.ClientResponse.html
+    pub async fn send_stream<S, E>(self, stream: S) -> AwcResult
+    where
+        S: Stream<Item = Result<Bytes, E>> + Unpin + 'static,
+        E: Into<Error> + 'static,
+    {
+        self.trace_request(|request| request.send_stream(stream))
+            .await
+    }
+
+    async fn trace_request<F, R>(mut self, f: F) -> AwcResult
+    where
+        F: FnOnce(ClientRequest) -> R,
+        R: Future<Output = AwcResult>,
+    {
+        let tracer = global::tracer("actix-client");
+        let span = tracer
+            .span_builder(
+                format!(
+                    "{} {}{}{}",
+                    self.request.get_method(),
+                    self.request
+                        .get_uri()
+                        .scheme()
+                        .map(|s| format!("{}://", s.as_str()))
+                        .unwrap_or_else(String::new),
+                    self.request
+                        .get_uri()
+                        .authority()
+                        .map(|s| s.as_str())
+                        .unwrap_or(""),
+                    self.request.get_uri().path()
+                )
+                .as_str(),
+            )
+            .with_kind(SpanKind::Client)
+            .with_attributes(vec![
+                KeyValue::new(HTTP_METHOD_ATTRIBUTE, self.request.get_method().as_str()),
+                KeyValue::new(
+                    HTTP_URL_ATTRIBUTE,
+                    self.request.get_uri().to_string().as_str(),
+                ),
+                KeyValue::new(
+                    HTTP_FLAVOR_ATTRIBUTE,
+                    format!("{:?}", self.request.get_version()).replace("HTTP/", ""),
+                ),
+            ])
+            .start(&tracer);
+        let cx = self.cx.with_span(span);
+
+        global::get_http_text_propagator(|injector| {
+            injector.inject_context(&cx, &mut ActixClientCarrier::new(&mut self.request));
+        });
+
+        f(self.request)
+            .inspect_ok(|res| record_response(&res, &cx))
+            .inspect_err(|err| record_err(err, &cx))
+            .await
+    }
+}
+
+fn record_response<T>(response: &ClientResponse<T>, cx: &Context) {
+    let span = cx.span();
+    span.set_attribute(KeyValue::new(
+        HTTP_STATUS_CODE_ATTRIBUTE,
+        Value::U64(response.status().as_u16() as u64),
+    ));
+    if let Some(reason) = response.status().canonical_reason() {
+        span.set_attribute(KeyValue::new(HTTP_STATUS_TEXT_ATTRIBUTE, reason));
+    }
+    span.end();
+}
+
+fn record_err<T: fmt::Debug>(err: T, cx: &Context) {
+    let span = cx.span();
+    span.set_status(StatusCode::Internal, format!("{:?}", err));
+    span.end();
 }
 
 struct ActixClientCarrier<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,33 +4,32 @@
 //!
 //! This crate allows you to easily instrument client and server requests.
 //!
-//! * Client requests can be traced by using the [`with_tracing`] function.
+//! * Client requests can be traced by using the [`ClientExt::trace_request`] function.
 //! * Server requests can be traced by using the [`RequestTracing`] struct.
 //!
-//! [`with_tracing`]: fn.with_tracing.html
+//! [`ClientExt::trace_request`]: trait.ClientExt.html#method.trace_request
 //! [`RequestTracing`]: struct.RequestTracing.html
 //!
 //! ### Client Request Example:
-//! ```rust,no_run
+//! ```no_run
 //! use actix_web::client;
+//! use actix_web_opentelemetry::ClientExt;
 //! use futures::Future;
 //!
 //! async fn execute_request(client: &client::Client) -> Result<(), client::SendRequestError> {
-//!     let mut res = actix_web_opentelemetry::with_tracing(
-//!         client.get("http://localhost:8080"),
-//!         |request| request.send()
-//!     )
-//!     .await;
+//!     let res = client
+//!         .get("http://localhost:8080")
+//!         .trace_request()
+//!         .send()
+//!         .await?;
 //!
-//!     res.and_then(|res| {
-//!         println!("Response: {:?}", res);
-//!         Ok(())
-//!     })
+//!     println!("Response: {:?}", res);
+//!     Ok(())
 //! }
 //! ```
 //!
-//! ### Server middlware example:
-//! ```rust,no_run
+//! ### Server middleware example:
+//! ```no_run
 //! use actix_web::{web, App, HttpServer};
 //! use actix_web_opentelemetry::RequestTracing;
 //! use opentelemetry::api;
@@ -65,8 +64,9 @@
 mod client;
 mod middleware;
 
+#[allow(deprecated)]
 pub use {
-    client::with_tracing,
+    client::{with_tracing, ClientExt, InstrumentedClientRequest},
     middleware::metrics::{RequestMetrics, RequestMetricsMiddleware},
     middleware::route_formatter::{RouteFormatter, UuidWildcardFormatter},
     middleware::trace::RequestTracing,


### PR DESCRIPTION
1. Simplify client tracing

Previous:
```rust
let mut response = actix_web_opentelemetry::with_tracing(
    client.get("http://localhost:8080/users/103240ba-3d8d-4695-a176-e19cbc627483?a=1"),
    |request| request.send(),
)
.await
```

New:
```rust
let mut response = client
    .get("http://localhost:8080/users/103240ba-3d8d-4695-a176-e19cbc627483?a=1")
    .trace_request()
    .send()
    .await
```

2. Use global propagator API for server tracing to avoid need to specify propagator.
