### PR TITLE
Prepare for 0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [v0.5.0](https://github.com/OutThereLabs/actix-web-opentelemetry/compare/v0.4.0...v0.5.0)
+
+### Added
+
+- Trace actix client requests with `ClientExt::trace_request` or
+  `ClientExt::trace_request_with_context`. #17
+
+### Changed
+
+- Update to OpenTelemetry v0.8.0 #18
+- Deprecated `with_tracing` fn. Use `ClientExt` instead. #17
+
+
 ## [v0.4.0](https://github.com/OutThereLabs/actix-web-opentelemetry/compare/v0.3.0...v0.4.0)
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-opentelemetry"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Julian Tescher <julian@outtherelabs.com>"]
 description = "OpenTelemetry integration for Actix Web apps"
 homepage = "https://github.com/OutThereLabs/actix-web-opentelemetry"


### PR DESCRIPTION
Changelog:

### Added

- Trace actix client requests with `ClientExt::trace_request` or `ClientExt::trace_request_with_context`. #17

### Changed

- Update to OpenTelemetry v0.8.0 #18
- Deprecated `with_tracing` fn. Use `ClientExt` instead. #17