### PR TITLE
Allow specifying route format with custom regex

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,8 @@ mod middleware;
 pub use {
     client::{with_tracing, ClientExt, InstrumentedClientRequest},
     middleware::metrics::{RequestMetrics, RequestMetricsMiddleware},
-    middleware::route_formatter::{RouteFormatter, UuidWildcardFormatter},
+    middleware::route_formatter::{
+        PassThroughFormatter, RegexFormatter, RouteFormatter, UuidWildcardFormatter, UUID_REGEX,
+    },
     middleware::trace::RequestTracing,
 };

--- a/src/middleware/metrics.rs
+++ b/src/middleware/metrics.rs
@@ -1,5 +1,5 @@
 //! # Metrics Middleware
-use crate::{RouteFormatter, UuidWildcardFormatter};
+use crate::{PassThroughFormatter, RouteFormatter};
 use actix_web::dev;
 use futures::{
     future::{self, FutureExt},
@@ -50,7 +50,7 @@ where
     }
 }
 
-impl<F> Default for RequestMetrics<api::NoopMeter, UuidWildcardFormatter, F>
+impl<F> Default for RequestMetrics<api::NoopMeter, PassThroughFormatter, F>
 where
     F: Fn(&dev::ServiceRequest) -> bool + Send + Clone,
 {
@@ -60,7 +60,7 @@ where
         let http_requests_duration_seconds = sdk.new_f64_measure("", MetricOptions::default());
         RequestMetrics {
             sdk,
-            route_formatter: UuidWildcardFormatter::new(),
+            route_formatter: PassThroughFormatter,
             should_render_metrics: None,
             http_requests_total,
             http_requests_duration_seconds,

--- a/src/middleware/route_formatter.rs
+++ b/src/middleware/route_formatter.rs
@@ -3,31 +3,125 @@
 //! Format routes from paths.
 use regex::Regex;
 
+/// A regular expression for matching UUIDs.
+pub const UUID_REGEX: &str =
+    r"[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}";
+
 /// Interface for formatting routes from paths
+///
+/// # Examples
+///
+/// Using the built in regex route formatter:
+///
+/// ```
+/// use regex::Regex;
+/// use actix_web_opentelemetry::{RouteFormatter, RegexFormatter, UUID_REGEX};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let uuid_formatter = RegexFormatter::new(UUID_REGEX, "*")?;
+/// let uuid_path = "/users/4f5accfe-45d2-43b1-bf10-fdad708732a8";
+/// assert_eq!(uuid_formatter.format(uuid_path), "/users/*".to_string());
+///
+/// let numeric_formatter = RegexFormatter::new(r"\d+", ":id")?;
+/// assert_eq!(numeric_formatter.format("/users/123"), "/users/:id".to_string());
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Or create your own custom formatter:
+///
+/// ```
+/// use actix_web_opentelemetry::RouteFormatter;
+///
+/// // A formatter to ensure all paths are reported as lowercase.
+/// struct MyLowercaseFormatter;
+///
+/// impl RouteFormatter for MyLowercaseFormatter {
+///     fn format(&self, path: &str) -> String {
+///         path.to_lowercase()
+///     }
+/// }
+///
+/// // now a request with path `/USERS/123` would be recorded as `/users/123`
+/// ```
 pub trait RouteFormatter {
     /// Function from path to route.
     /// e.g. /users/123 -> /users/:id
-    fn format(&self, uri: &str) -> String;
+    fn format(&self, path: &str) -> String;
+}
+
+/// A route formatter that uses a regular expression to replace path components.
+///
+/// # Examples
+///
+/// ```
+/// use regex::Regex;
+/// use actix_web_opentelemetry::{RouteFormatter, RegexFormatter, UUID_REGEX};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let uuid_formatter = RegexFormatter::new(UUID_REGEX, "*")?;
+/// let uuid_path = "/users/4f5accfe-45d2-43b1-bf10-fdad708732a8";
+/// assert_eq!(uuid_formatter.format(uuid_path), "/users/*".to_string());
+///
+/// let numeric_formatter = RegexFormatter::new(r"\d+", ":id")?;
+/// assert_eq!(numeric_formatter.format("/users/123"), "/users/:id".to_string());
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone, Debug)]
+pub struct RegexFormatter {
+    regex: Regex,
+    replacement: &'static str,
+}
+
+impl RegexFormatter {
+    /// Create a new `RegexFormatter`
+    pub fn new(re: &str, replacement: &'static str) -> Result<Self, regex::Error> {
+        let regex = Regex::new(re)?;
+        Ok(RegexFormatter { regex, replacement })
+    }
+}
+
+impl RouteFormatter for RegexFormatter {
+    fn format(&self, path: &str) -> String {
+        self.regex.replace_all(path, self.replacement).into_owned()
+    }
+}
+
+/// A formatter that passes the path through unchanged.
+#[derive(Clone, Debug, Default)]
+pub struct PassThroughFormatter;
+
+impl RouteFormatter for PassThroughFormatter {
+    fn format(&self, path: &str) -> String {
+        path.to_string()
+    }
 }
 
 /// UUID wildcard formatter replaces UUIDs with asterisks.
-#[derive(Clone, Debug, Default)]
-pub struct UuidWildcardFormatter {}
+#[derive(Clone, Debug)]
+pub struct UuidWildcardFormatter {
+    formatter: RegexFormatter,
+}
+
+impl Default for UuidWildcardFormatter {
+    fn default() -> Self {
+        UuidWildcardFormatter {
+            formatter: RegexFormatter::new(UUID_REGEX, "*").unwrap(),
+        }
+    }
+}
 
 impl UuidWildcardFormatter {
     /// Create a new `UuidWildcardFormatter`
+    #[deprecated = "please use RegexFormatter instead"]
     pub fn new() -> Self {
-        UuidWildcardFormatter {}
+        UuidWildcardFormatter::default()
     }
 }
 
 impl RouteFormatter for UuidWildcardFormatter {
-    /// Function from path to route
-    /// e.g. /users/4f5accfe-45d2-43b1-bf10-fdad708732a8 -> /users/*
-    fn format(&self, uri: &str) -> String {
-        lazy_static::lazy_static! {
-            static ref UUID: Regex = Regex::new(r"[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}").unwrap();
-        }
-        UUID.replace_all(uri, "*").into_owned()
+    fn format(&self, path: &str) -> String {
+        self.formatter.format(path)
     }
 }


### PR DESCRIPTION
Custom format now can be added via:

```rust
HttpServer::new(|| {
    let id_formatter = RegexFormatter::new(r"\d+", ":id").unwrap();
    App::new()
        .wrap(RequestTracing::with_formatter(id_formatter)
        .service(web::resource("/").to(index))
})
.bind("127.0.0.1:8080")?
.run()
.await
```