### PR TITLE
Upgrade actix-web to version 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,11 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-actix-http = "1.0"
-actix-web = "2.0"
+actix-http = "2.0"
+actix-web = "3.0"
 futures = "0.3"
-lazy_static = "1.4"
 opentelemetry = "0.8"
-regex = "1.3"
 serde = "1.0"
 
 [dev-dependencies]
-actix-rt = "1.0"
 opentelemetry-jaeger = "0.7"
-thrift = "0.13"

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -49,7 +49,7 @@ fn init_tracer() -> io::Result<()> {
     Ok(())
 }
 
-#[actix_rt::main]
+#[actix_web::main]
 async fn main() -> io::Result<()> {
     init_tracer()?;
     let client = client::Client::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //!     "Hello world!"
 //! }
 //!
-//! #[actix_rt::main]
+//! #[actix_web::main]
 //! async fn main() -> std::io::Result<()> {
 //!     init_tracer();
 //!     HttpServer::new(|| {
@@ -68,8 +68,6 @@ mod middleware;
 pub use {
     client::{with_tracing, ClientExt, InstrumentedClientRequest},
     middleware::metrics::{RequestMetrics, RequestMetricsMiddleware},
-    middleware::route_formatter::{
-        PassThroughFormatter, RegexFormatter, RouteFormatter, UuidWildcardFormatter, UUID_REGEX,
-    },
+    middleware::route_formatter::RouteFormatter,
     middleware::trace::RequestTracing,
 };


### PR DESCRIPTION
* Switch to new Actix 3 route extraction via [match_pattern](https://docs.rs/actix-web/3/actix_web/struct.HttpRequest.html#method.match_pattern).
* Remove old route formatters that were workarounds for missing match pattern method above.
* `RouteFormatter` trait can still be used to adjust the default match pattern output as it is not run on the resulting output pattern.

Resolves #24