### PR TITLE
Update opentelemetry to 0.9.x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,4 +17,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --all-features --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,18 @@ keywords = ["actix", "actix-web", "opentelemetry", "jaeger", "prometheus"]
 license = "MIT"
 edition = "2018"
 
+[features]
+metrics = ["opentelemetry/metrics", "opentelemetry-prometheus", "prometheus"]
+
 [dependencies]
-actix-http = "2.0"
-actix-web = "3.0"
+actix-http = { version = "2.0", features = ["compress"] }
+actix-web = { version = "3.0", default-features = false, features = ["compress"] }
 futures = "0.3"
-opentelemetry = "0.8"
+opentelemetry = { version = "0.9", default-features = false, features = ["trace", "metrics", "tokio"] }
+opentelemetry-prometheus = { version = "0.2", optional = true }
+opentelemetry-semantic-conventions = "0.1"
+prometheus = { version = "0.10", default-features = false, optional = true }
 serde = "1.0"
 
 [dev-dependencies]
-opentelemetry-jaeger = "0.7"
+opentelemetry-jaeger = { version = "0.8", features = ["tokio"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,25 @@
 //! # Actix Web OpenTelemetry
 //!
-//! [OpenTelemetry](https://opentelemetry.io/) integration for [Actix Web](https://actix.rs/).
+//! [OpenTelemetry] integration for [Actix Web].
 //!
 //! This crate allows you to easily instrument client and server requests.
 //!
 //! * Client requests can be traced by using the [`ClientExt::trace_request`] function.
-//! * Server requests can be traced by using the [`RequestTracing`] struct.
+//! * Server requests can be traced by using the [`RequestTracing`] middleware.
 //!
+//! The `metrics` feature allows you to expose request metrics to [Prometheus].
+//!
+//! * Metrics can be tracked using the [`RequestMetrics`] middleware.
+//!
+//! [OpenTelemetry]: https://opentelemetry.io
+//! [Actix Web]: https://actix.rs
 //! [`ClientExt::trace_request`]: trait.ClientExt.html#method.trace_request
 //! [`RequestTracing`]: struct.RequestTracing.html
+//! [Prometheus]: https://prometheus.io
+//! [`RequestMetrics`]: struct.RequestMetrics.html
 //!
-//! ### Client Request Example:
+//! ### Client Request Examples:
+//!
 //! ```no_run
 //! use actix_web::client;
 //! use actix_web_opentelemetry::ClientExt;
@@ -19,6 +28,7 @@
 //! async fn execute_request(client: &client::Client) -> Result<(), client::SendRequestError> {
 //!     let res = client
 //!         .get("http://localhost:8080")
+//!         // Add `trace_request` before `send` to any awc request to add instrumentation
 //!         .trace_request()
 //!         .send()
 //!         .await?;
@@ -28,17 +38,15 @@
 //! }
 //! ```
 //!
-//! ### Server middleware example:
+//! ### Server middleware examples:
+//!
+//! Tracing and metrics middleware can be used together or independently.
+//!
+//! Tracing server example:
+//!
 //! ```no_run
 //! use actix_web::{web, App, HttpServer};
 //! use actix_web_opentelemetry::RequestTracing;
-//! use opentelemetry::api;
-//!
-//! fn init_tracer() {
-//!     // Replace this no-op provider with something like:
-//!     // https://docs.rs/opentelemetry-jaeger
-//!     opentelemetry::global::set_provider(api::NoopProvider {});
-//! }
 //!
 //! async fn index() -> &'static str {
 //!     "Hello world!"
@@ -46,10 +54,14 @@
 //!
 //! #[actix_web::main]
 //! async fn main() -> std::io::Result<()> {
-//!     init_tracer();
+//!     // Install an OpenTelemetry trace pipeline.
+//!     // Swap for https://docs.rs/opentelemetry-jaeger or other compatible
+//!     // exporter to send trace information to your collector.
+//!     opentelemetry::exporter::trace::stdout::new_pipeline().install();
+//!
 //!     HttpServer::new(|| {
 //!         App::new()
-//!             .wrap(RequestTracing::default())
+//!             .wrap(RequestTracing::new())
 //!             .service(web::resource("/").to(index))
 //!     })
 //!     .bind("127.0.0.1:8080")?
@@ -58,16 +70,47 @@
 //! }
 //! ```
 //!
+//! Request metrics middleware:
+//!
+//! ```no_run
+//! use actix_web::{dev, http, web, App, HttpRequest, HttpServer};
+//! # #[cfg(feature = "metrics")]
+//! use actix_web_opentelemetry::RequestMetrics;
+//! use opentelemetry::global;
+//!
+//! # #[cfg(feature = "metrics")]
+//! #[actix_web::main]
+//! async fn main() -> std::io::Result<()> {
+//!     let exporter = opentelemetry_prometheus::exporter().init();
+//!     let meter = global::meter("actix_web");
+//!
+//!     // Optional predicate to determine which requests render the prometheus metrics
+//!     let metrics_route = |req: &dev::ServiceRequest| {
+//!         req.path() == "/metrics" && req.method() == http::Method::GET
+//!     };
+//!
+//!     // Request metrics middleware
+//!     let request_metrics = RequestMetrics::new(meter, Some(metrics_route), Some(exporter));
+//!
+//!     // Run actix server, metrics are now available at http://localhost:8080/metrics
+//!     HttpServer::new(move || App::new().wrap(request_metrics.clone()))
+//!         .bind("localhost:8080")?
+//!         .run()
+//!         .await
+//! }
+//! # #[cfg(not(feature = "metrics"))]
+//! # fn main() {}
+//! ```
 #![deny(missing_docs, unreachable_pub, missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
 
 mod client;
 mod middleware;
 
-#[allow(deprecated)]
+#[cfg(feature = "metrics")]
+pub use middleware::metrics::{RequestMetrics, RequestMetricsMiddleware};
 pub use {
-    client::{with_tracing, ClientExt, InstrumentedClientRequest},
-    middleware::metrics::{RequestMetrics, RequestMetricsMiddleware},
+    client::{ClientExt, InstrumentedClientRequest},
     middleware::route_formatter::RouteFormatter,
     middleware::trace::RequestTracing,
 };

--- a/src/middleware/metrics.rs
+++ b/src/middleware/metrics.rs
@@ -5,41 +5,67 @@ use futures::{
     future::{self, FutureExt},
     Future,
 };
-use opentelemetry::{
-    api::{self, Counter, Measure, Meter, MetricOptions},
-    exporter::metrics::prometheus::{self, Encoder},
+use opentelemetry::api::{
+    metrics::{
+        noop::NoopMeterProvider, Counter, Meter, MeterProvider, MetricsError, ValueRecorder,
+    },
+    Key,
 };
+use opentelemetry::global;
+use opentelemetry_prometheus::PrometheusExporter;
+use prometheus::{Encoder, TextEncoder};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::Poll;
 use std::time::SystemTime;
 
 /// Request metrics tracking
+///
+/// # Examples
+///
+/// ```no_run
+/// use actix_web::{dev, http, web, App, HttpRequest, HttpServer};
+/// use actix_web_opentelemetry::RequestMetrics;
+/// use opentelemetry::global;
+///
+/// # async fn start_server() -> std::io::Result<()> {
+/// let exporter = opentelemetry_prometheus::exporter().init();
+/// let meter = global::meter("actix_web");
+///
+/// // Optional predicate to determine which requests render the prometheus metrics
+/// let metrics_route = |req: &dev::ServiceRequest| {
+///     req.path() == "/metrics" && req.method() == http::Method::GET
+/// };
+///
+/// // Request metrics middleware
+/// let request_metrics = RequestMetrics::new(meter, Some(metrics_route), Some(exporter));
+///
+/// // Run actix server, metrics are now available at http://localhost:8080/metrics
+/// HttpServer::new(move || App::new().wrap(request_metrics.clone()))
+///     .bind("localhost:8080")?
+///     .run()
+///     .await
+/// # }
+/// ```
 #[derive(Debug)]
-pub struct RequestMetrics<M, F>
+pub struct RequestMetrics<F>
 where
-    M: api::Meter,
-    M::I64Counter: Clone,
-    M::F64Measure: Clone,
     F: Fn(&dev::ServiceRequest) -> bool + Send + Clone,
 {
-    sdk: Arc<M>,
+    exporter: PrometheusExporter,
     route_formatter: Option<Arc<dyn RouteFormatter + Send + Sync + 'static>>,
     should_render_metrics: Option<F>,
-    http_requests_total: M::I64Counter,
-    http_requests_duration_seconds: M::F64Measure,
+    http_requests_total: Counter<u64>,
+    http_requests_duration_seconds: ValueRecorder<f64>,
 }
 
-impl<M, F> Clone for RequestMetrics<M, F>
+impl<F> Clone for RequestMetrics<F>
 where
-    M: api::Meter,
-    M::I64Counter: Clone,
-    M::F64Measure: Clone,
     F: Fn(&dev::ServiceRequest) -> bool + Send + Clone,
 {
     fn clone(&self) -> Self {
         RequestMetrics {
-            sdk: self.sdk.clone(),
+            exporter: self.exporter.clone(),
             route_formatter: self.route_formatter.clone(),
             should_render_metrics: self.should_render_metrics.clone(),
             http_requests_total: self.http_requests_total.clone(),
@@ -48,53 +74,46 @@ where
     }
 }
 
-impl<F> Default for RequestMetrics<api::NoopMeter, F>
+impl<F> Default for RequestMetrics<F>
 where
     F: Fn(&dev::ServiceRequest) -> bool + Send + Clone,
 {
     fn default() -> Self {
-        let sdk = Arc::new(api::NoopMeter {});
-        let http_requests_total = sdk.new_i64_counter("", MetricOptions::default());
-        let http_requests_duration_seconds = sdk.new_f64_measure("", MetricOptions::default());
-        RequestMetrics {
-            sdk,
-            route_formatter: None,
-            should_render_metrics: None,
-            http_requests_total,
-            http_requests_duration_seconds,
-        }
+        let provider = NoopMeterProvider;
+        let meter = provider.meter("noop");
+        RequestMetrics::new(meter, None, None)
     }
 }
 
-impl<M, F> RequestMetrics<M, F>
+const ROUTE_KEY: Key = Key::from_static_str("route");
+const METHOD_KEY: Key = Key::from_static_str("method");
+const STATUS_KEY: Key = Key::from_static_str("status");
+
+impl<F> RequestMetrics<F>
 where
-    M: api::Meter,
-    M::I64Counter: Clone,
-    M::F64Measure: Clone,
     F: Fn(&dev::ServiceRequest) -> bool + Send + Clone,
 {
     /// Create new `RequestMetrics`
-    pub fn new(sdk: M, should_render_metrics: Option<F>) -> Self {
-        let standard_keys = vec![
-            api::Key::new("route"),
-            api::Key::new("method"),
-            api::Key::new("status"),
-        ];
-        let http_requests_total = sdk.new_i64_counter(
-            "http_requests_total",
-            MetricOptions::default()
-                .with_description("HTTP requests per route")
-                .with_keys(standard_keys.clone()),
-        );
-        let http_requests_duration_seconds = sdk.new_f64_measure(
-            "http_requests_duration",
-            MetricOptions::default()
-                .with_description("HTTP request duration per route")
-                .with_unit(api::Unit::new("seconds"))
-                .with_keys(standard_keys),
-        );
+    pub fn new(
+        meter: Meter,
+        should_render_metrics: Option<F>,
+        exporter: Option<PrometheusExporter>,
+    ) -> Self {
+        let exporter = exporter.unwrap_or_else(|| opentelemetry_prometheus::exporter().init());
+        let http_requests_total = meter
+            .u64_counter("http_requests_total")
+            .with_description("HTTP requests per route")
+            .init();
+
+        let http_requests_duration_seconds = meter
+            .f64_value_recorder("http_requests_duration")
+            .with_description("HTTP request duration per route")
+            // TODO: https://github.com/open-telemetry/opentelemetry-rust/issues/276
+            // .with_unit(Unit::new("seconds"))
+            .init();
+
         RequestMetrics {
-            sdk: Arc::new(sdk),
+            exporter,
             route_formatter: None,
             should_render_metrics,
             http_requests_total,
@@ -112,15 +131,18 @@ where
     }
 
     fn metrics(&self) -> String {
-        let mut buffer = vec![];
-        prometheus::TextEncoder::new()
-            .encode(&prometheus::gather(), &mut buffer)
-            .unwrap();
-        String::from_utf8(buffer).unwrap()
+        let encoder = TextEncoder::new();
+        let metric_families = self.exporter.registry().gather();
+        let mut buf = Vec::new();
+        if let Err(err) = encoder.encode(&metric_families[..], &mut buf) {
+            global::handle_error(MetricsError::Other(err.to_string()));
+        }
+
+        String::from_utf8(buf).unwrap_or_default()
     }
 }
 
-impl<S, B, M, F> dev::Transform<S> for RequestMetrics<M, F>
+impl<S, B, F> dev::Transform<S> for RequestMetrics<F>
 where
     S: dev::Service<
         Request = dev::ServiceRequest,
@@ -129,15 +151,12 @@ where
     >,
     S::Future: 'static,
     B: 'static,
-    M: api::Meter + 'static,
-    M::I64Counter: Clone,
-    M::F64Measure: Clone,
     F: Fn(&dev::ServiceRequest) -> bool + Send + Clone + 'static,
 {
     type Request = dev::ServiceRequest;
     type Response = dev::ServiceResponse<B>;
     type Error = actix_web::Error;
-    type Transform = RequestMetricsMiddleware<S, M, F>;
+    type Transform = RequestMetricsMiddleware<S, F>;
     type InitError = ();
     type Future = future::Ready<Result<Self::Transform, Self::InitError>>;
 
@@ -151,18 +170,15 @@ where
 
 /// Request metrics middleware
 #[allow(missing_debug_implementations)]
-pub struct RequestMetricsMiddleware<S, M, F>
+pub struct RequestMetricsMiddleware<S, F>
 where
-    M: api::Meter,
-    M::I64Counter: Clone,
-    M::F64Measure: Clone,
     F: Fn(&dev::ServiceRequest) -> bool + Send + Clone,
 {
     service: S,
-    inner: Arc<RequestMetrics<M, F>>,
+    inner: Arc<RequestMetrics<F>>,
 }
 
-impl<S, B, M, F> dev::Service for RequestMetricsMiddleware<S, M, F>
+impl<S, B, F> dev::Service for RequestMetricsMiddleware<S, F>
 where
     S: dev::Service<
         Request = dev::ServiceRequest,
@@ -171,9 +187,6 @@ where
     >,
     S::Future: 'static,
     B: 'static,
-    M: api::Meter + 'static,
-    M::I64Counter: Clone,
-    M::F64Measure: Clone,
     F: Fn(&dev::ServiceRequest) -> bool + Send + Clone + 'static,
 {
     type Request = dev::ServiceRequest;
@@ -203,9 +216,7 @@ where
         } else {
             let timer = SystemTime::now();
             let request_metrics = self.inner.clone();
-            let mut route = req
-                .match_pattern()
-                .unwrap_or_else(|| "unmatched".to_string());
+            let mut route = req.match_pattern().unwrap_or_else(|| "default".to_string());
             if let Some(formatter) = &self.inner.route_formatter {
                 route = formatter.format(&route);
             }
@@ -214,15 +225,15 @@ where
             Box::pin(self.service.call(req).map(move |res| {
                 // Ignore actix errors for metrics
                 if let Ok(res) = res {
-                    let standard_labels = request_metrics.sdk.labels(vec![
-                        api::KeyValue::new("route", route.as_str()),
-                        api::KeyValue::new("method", method.as_str()),
-                        api::KeyValue::new("status", api::Value::U64(res.status().as_u16() as u64)),
-                    ]);
-                    request_metrics.http_requests_total.add(1, &standard_labels);
+                    let labels = vec![
+                        ROUTE_KEY.string(route),
+                        METHOD_KEY.string(method),
+                        STATUS_KEY.u64(res.status().as_u16() as u64),
+                    ];
+                    request_metrics.http_requests_total.add(1, &labels);
                     request_metrics.http_requests_duration_seconds.record(
                         timer.elapsed().map(|t| t.as_secs_f64()).unwrap_or_default(),
-                        &standard_labels,
+                        &labels,
                     );
 
                     Ok(res)

--- a/src/middleware/metrics.rs
+++ b/src/middleware/metrics.rs
@@ -192,6 +192,7 @@ where
     type Request = dev::ServiceRequest;
     type Response = dev::ServiceResponse<B>;
     type Error = actix_web::Error;
+    #[allow(clippy::type_complexity)]
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
 
     fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "metrics")]
 pub(crate) mod metrics;
 pub(crate) mod route_formatter;
 pub(crate) mod trace;

--- a/src/middleware/trace.rs
+++ b/src/middleware/trace.rs
@@ -6,46 +6,26 @@ use futures::{
     Future,
 };
 use opentelemetry::api::{
-    self, Context, FutureExt as OtelFutureExt, KeyValue, StatusCode, TraceContextExt, Tracer, Value,
+    propagation::Extractor,
+    trace::{FutureExt as OtelFutureExt, SpanKind, StatusCode, TraceContextExt, Tracer},
+    Context,
 };
 use opentelemetry::global;
+use opentelemetry_semantic_conventions::trace::{
+    HTTP_CLIENT_IP, HTTP_FLAVOR, HTTP_HOST, HTTP_METHOD, HTTP_ROUTE, HTTP_SCHEME, HTTP_SERVER_NAME,
+    HTTP_STATUS_CODE, HTTP_TARGET, HTTP_USER_AGENT, NET_HOST_PORT, NET_PEER_IP,
+};
 use std::pin::Pin;
 use std::rc::Rc;
 use std::task::Poll;
-
-// Http common attributes
-const HTTP_METHOD_ATTRIBUTE: &str = "http.method";
-const HTTP_TARGET_ATTRIBUTE: &str = "http.target";
-const HTTP_SCHEME_ATTRIBUTE: &str = "http.scheme";
-const HTTP_STATUS_CODE_ATTRIBUTE: &str = "http.status_code";
-const HTTP_STATUS_TEXT_ATTRIBUTE: &str = "http.status_text";
-const HTTP_FLAVOR_ATTRIBUTE: &str = "http.flavor";
-const HTTP_USER_AGENT_ATTRIBUTE: &str = "http.user_agent";
-
-// Http server attributes
-const HTTP_HOST_ATTRIBUTE: &str = "http.host";
-const HTTP_SERVER_NAME_ATTRIBUTE: &str = "http.server_name";
-const HTTP_ROUTE_ATTRIBUTE: &str = "http.route";
-const HTTP_CLIENT_IP_ATTRIBUTE: &str = "http.client_ip";
-const NET_HOST_PORT_ATTRIBUTE: &str = "net.host.port";
 
 /// Request tracing middleware.
 ///
 /// # Examples:
 ///
 /// ```no_run
-/// #[macro_use]
-/// extern crate actix_web;
-///
 /// use actix_web::{web, App, HttpServer};
 /// use actix_web_opentelemetry::RequestTracing;
-/// use opentelemetry::api;
-///
-/// fn init_tracer() {
-///     // Replace this no-op provider with something like:
-///     // https://docs.rs/opentelemetry-jaeger
-///     opentelemetry::global::set_provider(api::NoopProvider {});
-/// }
 ///
 /// async fn index() -> &'static str {
 ///     "Hello world!"
@@ -53,7 +33,11 @@ const NET_HOST_PORT_ATTRIBUTE: &str = "net.host.port";
 ///
 /// #[actix_web::main]
 /// async fn main() -> std::io::Result<()> {
-///     init_tracer();
+///     // Install an OpenTelemetry trace pipeline.
+///     // Swap for https://docs.rs/opentelemetry-jaeger or other compatible
+///     // exporter to send trace information to your collector.
+///     opentelemetry::exporter::trace::stdout::new_pipeline().install();
+///
 ///     HttpServer::new(|| {
 ///         App::new()
 ///             .wrap(RequestTracing::new())
@@ -172,52 +156,61 @@ where
     }
 
     fn call(&mut self, mut req: ServiceRequest) -> Self::Future {
-        let _parent_context = global::get_http_text_propagator(|propagator| {
+        let _parent_context = global::get_text_map_propagator(|propagator| {
             propagator.extract(&RequestHeaderCarrier::new(req.headers_mut()))
         })
         .attach();
         let tracer = global::tracer("actix-web-opentelemetry");
-        let mut http_route = req
-            .match_pattern()
-            .unwrap_or_else(|| "unmatched".to_string());
+        let mut http_route = req.match_pattern().unwrap_or_else(|| "default".to_string());
         if let Some(formatter) = &self.route_formatter {
             http_route = formatter.format(&http_route);
         }
+        let conn_info = req.connection_info();
         let mut builder = tracer.span_builder(&http_route);
-        builder.span_kind = Some(api::SpanKind::Server);
+        builder.span_kind = Some(SpanKind::Server);
         let mut attributes = vec![
-            KeyValue::new(HTTP_METHOD_ATTRIBUTE, req.method().as_str()),
-            KeyValue::new(
-                HTTP_FLAVOR_ATTRIBUTE,
-                format!("{:?}", req.version()).replace("HTTP/", ""),
-            ),
-            KeyValue::new(HTTP_HOST_ATTRIBUTE, req.connection_info().host()),
-            KeyValue::new(HTTP_ROUTE_ATTRIBUTE, http_route),
-            KeyValue::new(HTTP_SCHEME_ATTRIBUTE, req.connection_info().scheme()),
+            HTTP_METHOD.string(req.method().as_str()),
+            HTTP_FLAVOR.string(format!("{:?}", req.version()).replace("HTTP/", "")),
+            HTTP_HOST.string(conn_info.host()),
+            HTTP_ROUTE.string(http_route),
+            HTTP_SCHEME.string(conn_info.scheme()),
         ];
         let server_name = req.app_config().host();
-        if server_name != req.connection_info().host() {
-            attributes.push(KeyValue::new(HTTP_SERVER_NAME_ATTRIBUTE, server_name));
+        if server_name != conn_info.host() {
+            attributes.push(HTTP_SERVER_NAME.string(server_name));
         }
-        if let Some(port) = req.connection_info().host().split_terminator(':').nth(1) {
-            attributes.push(KeyValue::new(NET_HOST_PORT_ATTRIBUTE, port))
+        if let Some(port) = conn_info
+            .host()
+            .split_terminator(':')
+            .nth(1)
+            .and_then(|port| port.parse().ok())
+        {
+            attributes.push(NET_HOST_PORT.u64(port))
         }
         if let Some(path) = req.uri().path_and_query() {
-            attributes.push(KeyValue::new(HTTP_TARGET_ATTRIBUTE, path.as_str()))
+            attributes.push(HTTP_TARGET.string(path.as_str()))
         }
         if let Some(user_agent) = req
             .headers()
             .get(header::USER_AGENT)
             .and_then(|s| s.to_str().ok())
         {
-            attributes.push(KeyValue::new(HTTP_USER_AGENT_ATTRIBUTE, user_agent))
+            attributes.push(HTTP_USER_AGENT.string(user_agent))
         }
-        if let Some(remote) = req.connection_info().realip_remote_addr() {
-            attributes.push(KeyValue::new(HTTP_CLIENT_IP_ATTRIBUTE, remote))
+        let remote_addr = conn_info.realip_remote_addr();
+        if let Some(remote) = remote_addr {
+            attributes.push(HTTP_CLIENT_IP.string(remote))
+        }
+        if let Some(peer_addr) = req.peer_addr().map(|socket| socket.to_string()) {
+            if Some(peer_addr.as_str()) != remote_addr {
+                // Client is going through a proxy
+                attributes.push(NET_PEER_IP.string(peer_addr))
+            }
         }
         builder.attributes = Some(attributes);
         let span = tracer.build(builder);
         let cx = Context::current_with_span(span);
+        drop(conn_info);
 
         let fut = self
             .service
@@ -226,13 +219,7 @@ where
             .map(move |res| match res {
                 Ok(ok_res) => {
                     let span = cx.span();
-                    span.set_attribute(KeyValue::new(
-                        HTTP_STATUS_CODE_ATTRIBUTE,
-                        Value::U64(ok_res.status().as_u16() as u64),
-                    ));
-                    if let Some(reason) = ok_res.status().canonical_reason() {
-                        span.set_attribute(KeyValue::new(HTTP_STATUS_TEXT_ATTRIBUTE, reason));
-                    }
+                    span.set_attribute(HTTP_STATUS_CODE.u64(ok_res.status().as_u16() as u64));
                     let status_code = match ok_res.status().as_u16() {
                         100..=399 => StatusCode::OK,
                         401 => StatusCode::Unauthenticated,
@@ -246,7 +233,7 @@ where
                         500..=599 => StatusCode::Internal,
                         _ => StatusCode::Unknown,
                     };
-                    span.set_status(status_code, "".to_string());
+                    span.set_status(status_code, String::new());
                     span.end();
                     Ok(ok_res)
                 }
@@ -272,8 +259,12 @@ impl<'a> RequestHeaderCarrier<'a> {
     }
 }
 
-impl<'a> opentelemetry::api::Extractor for RequestHeaderCarrier<'a> {
+impl<'a> Extractor for RequestHeaderCarrier<'a> {
     fn get(&self, key: &str) -> Option<&str> {
         self.headers.get(key).and_then(|v| v.to_str().ok())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.headers.keys().map(|header| header.as_str()).collect()
     }
 }

--- a/src/middleware/trace.rs
+++ b/src/middleware/trace.rs
@@ -149,6 +149,7 @@ where
     type Request = ServiceRequest;
     type Response = ServiceResponse<B>;
     type Error = Error;
+    #[allow(clippy::type_complexity)]
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
 
     fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -220,6 +221,7 @@ where
                 Ok(ok_res) => {
                     let span = cx.span();
                     span.set_attribute(HTTP_STATUS_CODE.u64(ok_res.status().as_u16() as u64));
+                    #[allow(clippy::match_overlapping_arm)]
                     let status_code = match ok_res.status().as_u16() {
                         100..=399 => StatusCode::OK,
                         401 => StatusCode::Unauthenticated,


### PR DESCRIPTION
* Move request metrics behind `metrics` feature as it is still unstable in OpenTelemetry
* Remove default features from `actix-web` and `actix-http` dependencies
* Upgrade to `opentelemetry` 0.9.x
* Simplify docs and examples to use new trace/metrics pipelines
* Use `opentelemetry-semantic-conventions` for server and client key names
* Remove deprecated `actix_web_opentelemetry::with_tracing` function.
* Change default route name from `unmatched` to `default`

Resolves #27 
