### PR TITLE
Update to opentelemetry v0.12.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,15 @@ metrics = ["opentelemetry/metrics", "opentelemetry-prometheus", "prometheus"]
 actix-http = { version = "2.0", features = ["compress"] }
 actix-web = { version = "3.0", default-features = false, features = ["compress"] }
 futures = "0.3"
-opentelemetry = { version = "0.11", default-features = false, features = ["trace", "metrics", "tokio"] }
-opentelemetry-prometheus = { version = "0.4", optional = true }
-opentelemetry-semantic-conventions = "0.3"
-prometheus = { version = "0.10", default-features = false, optional = true }
+opentelemetry = { version = "0.12", default-features = false, features = ["trace", "metrics"] }
+opentelemetry-prometheus = { version = "0.5", optional = true }
+opentelemetry-semantic-conventions = "0.4"
+prometheus = { version = "0.11", default-features = false, optional = true }
 serde = "1.0"
 
 [dev-dependencies]
-opentelemetry-jaeger = { version = "0.10", features = ["tokio"] }
+opentelemetry-jaeger = { version = "0.11" }
+tokio = { version = "0.2", default-features = false, features = ["rt-core", "blocking", "time", "stream"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -7,25 +7,6 @@
 
 [OpenTelemetry](https://opentelemetry.io/) integration for [Actix Web](https://actix.rs/).
 
-### Exporter configuration
-
-[`actix-web`] uses [`tokio`] as the underlying executor, so exporters should be
-configured to be non-blocking:
-
-```toml
-[dependencies]
-# if exporting to jaeger, use the `tokio` feature.
-opentelemetry-jaeger = { version = "*", features = ["tokio"] }
-
-# if exporting to zipkin, use the `tokio` based `reqwest-client` feature.
-opentelemetry-zipkin = { version = "*", features = ["reqwest-client"], default-features = false }
-
-# ... ensure the same same for any other exporters
-```
-
-[`actix-web`]: https://crates.io/crates/actix-web
-[`tokio`]: https://crates.io/crates/tokio
-
 ### Execute client and server example
 
 ```console

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,6 +1,13 @@
 use actix_web::client;
 use actix_web_opentelemetry::ClientExt;
-use opentelemetry::{global, sdk::propagation::TraceContextPropagator};
+use opentelemetry::{
+    global,
+    sdk::{
+        export::trace::SpanExporter,
+        propagation::TraceContextPropagator,
+        trace::{BatchSpanProcessor, TracerProvider},
+    },
+};
 use std::error::Error;
 use std::io;
 
@@ -22,12 +29,29 @@ async fn execute_request(client: client::Client) -> io::Result<String> {
         .map_err(|err| io::Error::new(io::ErrorKind::Other, err))
 }
 
+// Compatibility with older tokio v0.2.x used by actix web v3. Not necessary with actic web v4.
+fn tokio_exporter_compat<T: SpanExporter + 'static>(exporter: T) -> BatchSpanProcessor {
+    let spawn = |fut| tokio::task::spawn_blocking(|| futures::executor::block_on(fut));
+    BatchSpanProcessor::builder(
+        exporter,
+        spawn,
+        tokio::time::delay_for,
+        tokio::time::interval,
+    )
+    .build()
+}
+
 #[actix_web::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     global::set_text_map_propagator(TraceContextPropagator::new());
-    let (_tracer, _uninstall) = opentelemetry_jaeger::new_pipeline()
+    let exporter = opentelemetry_jaeger::new_pipeline()
         .with_service_name("actix_client")
-        .install()?;
+        .init_exporter()
+        .expect("pipeline exporter error");
+    let tracer_provider = TracerProvider::builder()
+        .with_batch_exporter(tokio_exporter_compat(exporter))
+        .build();
+    let _uninstall = global::set_tracer_provider(tracer_provider);
 
     let client = client::Client::new();
     let response = execute_request(client).await?;

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,20 +1,43 @@
 use actix_web::{web, App, HttpRequest, HttpServer};
 use actix_web_opentelemetry::RequestTracing;
-use opentelemetry::{global, sdk::propagation::TraceContextPropagator};
+use opentelemetry::{
+    global,
+    sdk::{
+        export::trace::SpanExporter,
+        propagation::TraceContextPropagator,
+        trace::{BatchSpanProcessor, TracerProvider},
+    },
+};
 use std::io;
 
 async fn index(_req: HttpRequest, _path: actix_web::web::Path<String>) -> &'static str {
     "Hello world!"
 }
 
+// Compatibility with older tokio v0.2.x used by actix web v3. Not necessary with actix web v4.
+fn tokio_exporter_compat<T: SpanExporter + 'static>(exporter: T) -> BatchSpanProcessor {
+    let spawn = |fut| tokio::task::spawn_blocking(|| futures::executor::block_on(fut));
+    BatchSpanProcessor::builder(
+        exporter,
+        spawn,
+        tokio::time::delay_for,
+        tokio::time::interval,
+    )
+    .build()
+}
+
 #[actix_web::main]
 async fn main() -> io::Result<()> {
     // Start a new jaeger trace pipeline
     global::set_text_map_propagator(TraceContextPropagator::new());
-    let (_tracer, _uninstall) = opentelemetry_jaeger::new_pipeline()
+    let exporter = opentelemetry_jaeger::new_pipeline()
         .with_service_name("actix_server")
-        .install()
+        .init_exporter()
         .expect("pipeline install error");
+    let tracer_provider = TracerProvider::builder()
+        .with_batch_exporter(tokio_exporter_compat(exporter))
+        .build();
+    let _uninstall = global::set_tracer_provider(tracer_provider);
 
     // Start a new prometheus metrics pipeline if --features metrics is used
     #[cfg(feature = "metrics")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,25 +96,6 @@
 //! # #[cfg(not(feature = "metrics"))]
 //! # fn main() {}
 //! ```
-//!
-//! ### Exporter configuration
-//!
-//! [`actix-web`] uses [`tokio`] as the underlying executor, so exporters should be
-//! configured to be non-blocking:
-//!
-//! ```toml
-//! [dependencies]
-//! # if exporting to jaeger, use the `tokio` feature.
-//! opentelemetry-jaeger = { version = "*", features = ["tokio"] }
-//!
-//! # if exporting to zipkin, use the `tokio` based `reqwest-client` feature.
-//! opentelemetry-zipkin = { version = "*", features = ["reqwest-client"], default-features = false }
-//!
-//! # ... ensure the same same for any other exporters
-//! ```
-//!
-//! [`actix-web`]: https://crates.io/crates/actix-web
-//! [`tokio`]: https://crates.io/crates/tokio
 #![deny(missing_docs, unreachable_pub, missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(broken_intra_doc_links))]


### PR DESCRIPTION
Opentelemetry v0.12 supports tokio 1.0 which actix web 3.x does not support. Support for latest otel is added here by manually creating a tokio 0.2.x compatible batch span exporter in the examples.