### PR TITLE
Re-add jaeger tokio dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,14 @@ metrics = ["opentelemetry/metrics", "opentelemetry-prometheus", "prometheus"]
 actix-http = { version = "3.0.0-beta.3", default-features = false, features = ["compress"] }
 actix-web = { version = "4.0.0-beta.3", default-features = false, features = ["compress"] }
 futures = "0.3"
-opentelemetry = { version = "0.12", default-features = false, features = ["trace", "metrics"] }
+opentelemetry = { version = "0.12", default-features = false, features = ["trace", "metrics", "tokio-support"] }
 opentelemetry-prometheus = { version = "0.5", optional = true }
 opentelemetry-semantic-conventions = "0.4"
 prometheus = { version = "0.11", default-features = false, optional = true }
 serde = "1.0"
 
 [dev-dependencies]
-opentelemetry-jaeger = { version = "0.11" }
-opentelemetry = { version = "0.12", default-features = false, features = ["trace", "metrics", "tokio-support"] }
+opentelemetry-jaeger = { version = "0.11", features = ["tokio"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -7,6 +7,25 @@
 
 [OpenTelemetry](https://opentelemetry.io/) integration for [Actix Web](https://actix.rs/).
 
+### Exporter configuration
+
+[`actix-web`] uses [`tokio`] as the underlying executor, so exporters should be
+configured to be non-blocking:
+
+```toml
+[dependencies]
+# if exporting to jaeger, use the `tokio` feature.
+opentelemetry-jaeger = { version = "*", features = ["tokio"] }
+
+# if exporting to zipkin, use the `tokio` based `reqwest-client` feature.
+opentelemetry-zipkin = { version = "*", features = ["reqwest-client"], default-features = false }
+
+# ... ensure the same same for any other exporters
+```
+
+[`actix-web`]: https://crates.io/crates/actix-web
+[`tokio`]: https://crates.io/crates/tokio
+
 ### Execute client and server example
 
 ```console

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,5 +1,6 @@
 use actix_web::client;
 use actix_web_opentelemetry::ClientExt;
+use opentelemetry::{global, sdk::propagation::TraceContextPropagator};
 use std::error::Error;
 use std::io;
 
@@ -23,10 +24,11 @@ async fn execute_request(client: client::Client) -> io::Result<String> {
 
 #[actix_web::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    // Start a new jaeger trace pipeline
+    global::set_text_map_propagator(TraceContextPropagator::new());
     let (_tracer, _uninstall) = opentelemetry_jaeger::new_pipeline()
         .with_service_name("actix_client")
-        .install()
-        .expect("pipeline install error");
+        .install()?;
 
     let client = client::Client::new();
     let response = execute_request(client).await?;

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,5 +1,6 @@
 use actix_web::{web, App, HttpRequest, HttpServer};
 use actix_web_opentelemetry::RequestTracing;
+use opentelemetry::{global, sdk::propagation::TraceContextPropagator};
 use std::io;
 
 async fn index(_req: HttpRequest, _path: actix_web::web::Path<String>) -> &'static str {
@@ -8,6 +9,8 @@ async fn index(_req: HttpRequest, _path: actix_web::web::Path<String>) -> &'stat
 
 #[actix_web::main]
 async fn main() -> io::Result<()> {
+    // Start a new jaeger trace pipeline
+    global::set_text_map_propagator(TraceContextPropagator::new());
     let (_tracer, _uninstall) = opentelemetry_jaeger::new_pipeline()
         .with_service_name("actix_server")
         .install()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,25 @@
 //! # #[cfg(not(feature = "metrics"))]
 //! # fn main() {}
 //! ```
+//!
+//! ### Exporter configuration
+//!
+//! [`actix-web`] uses [`tokio`] as the underlying executor, so exporters should be
+//! configured to be non-blocking:
+//!
+//! ```toml
+//! [dependencies]
+//! # if exporting to jaeger, use the `tokio` feature.
+//! opentelemetry-jaeger = { version = "*", features = ["tokio"] }
+//!
+//! # if exporting to zipkin, use the `tokio` based `reqwest-client` feature.
+//! opentelemetry-zipkin = { version = "*", features = ["reqwest-client"], default-features = false }
+//!
+//! # ... ensure the same same for any other exporters
+//! ```
+//!
+//! [`actix-web`]: https://crates.io/crates/actix-web
+//! [`tokio`]: https://crates.io/crates/tokio
 #![deny(missing_docs, unreachable_pub, missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(broken_intra_doc_links))]


### PR DESCRIPTION
Now that we have tokio 1 support, re-enable the `tokio` feature in in jaeger for async exporting