### PR TITLE
Upgrade to latest actix-web beta releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,9 @@ edition = "2018"
 metrics = ["opentelemetry/metrics", "opentelemetry-prometheus", "prometheus"]
 
 [dependencies]
-actix-http = { version = "3.0.0-beta.3", default-features = false, features = ["compress"] }
-actix-web = { version = "4.0.0-beta.3", default-features = false, features = ["compress"] }
+actix-http = { version = "3.0.0-beta.4", default-features = false, features = ["compress"] }
+actix-web = { version = "4.0.0-beta.4", default-features = false, features = ["compress"] }
+awc = { version = "3.0.0-beta.3", default-features = false, features = ["compress"] }
 futures = "0.3"
 opentelemetry = { version = "0.12", default-features = false, features = ["trace", "metrics", "tokio-support"] }
 opentelemetry-prometheus = { version = "0.5", optional = true }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,10 +1,10 @@
-use actix_web::client;
 use actix_web_opentelemetry::ClientExt;
+use awc::Client;
 use opentelemetry::{global, sdk::propagation::TraceContextPropagator};
 use std::error::Error;
 use std::io;
 
-async fn execute_request(client: client::Client) -> io::Result<String> {
+async fn execute_request(client: Client) -> io::Result<String> {
     let mut response = client
         .get("http://localhost:8080/users/103240ba-3d8d-4695-a176-e19cbc627483?a=1")
         .trace_request()
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         .with_service_name("actix_client")
         .install()?;
 
-    let client = client::Client::new();
+    let client = Client::new();
     let response = execute_request(client).await?;
 
     println!("Response: {}", response);

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,10 +2,10 @@ use crate::util::http_method_str;
 use actix_http::{encoding::Decoder, Error, Payload, PayloadStream};
 use actix_web::{
     body::Body,
-    client::{ClientRequest, ClientResponse, SendRequestError},
     http::{HeaderName, HeaderValue},
     web::Bytes,
 };
+use awc::{error::SendRequestError, ClientRequest, ClientResponse};
 use futures::{future::TryFutureExt, Future, Stream};
 use opentelemetry::{
     global,
@@ -37,10 +37,10 @@ pub trait ClientExt {
     ///
     /// Example:
     /// ```no_run
-    /// use actix_web::client;
     /// use actix_web_opentelemetry::ClientExt;
+    /// use awc::{Client, error::SendRequestError};
     ///
-    /// async fn execute_request(client: &client::Client) -> Result<(), client::SendRequestError> {
+    /// async fn execute_request(client: &Client) -> Result<(), SendRequestError> {
     ///     let res = client.get("http://localhost:8080")
     ///         // Add `trace_request` before `send` to any awc request to add instrumentation
     ///         .trace_request()
@@ -63,11 +63,11 @@ pub trait ClientExt {
     ///[`actix_web::client::Client`]: actix_web::client::Client
     /// Example:
     /// ```no_run
-    /// use actix_web::client;
     /// use actix_web_opentelemetry::ClientExt;
+    /// use awc::{Client, error::SendRequestError};
     /// use opentelemetry::Context;
     ///
-    /// async fn execute_request(client: &client::Client) -> Result<(), client::SendRequestError> {
+    /// async fn execute_request(client: &Client) -> Result<(), SendRequestError> {
     ///     let res = client.get("http://localhost:8080")
     ///         // Add `trace_request_with_context` before `send` to any awc request to
     ///         // add instrumentation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,11 +16,11 @@
 //! ### Client Request Examples:
 //!
 //! ```no_run
-//! use actix_web::client;
+//! use awc::{Client, error::SendRequestError};
 //! use actix_web_opentelemetry::ClientExt;
 //! use futures::Future;
 //!
-//! async fn execute_request(client: &client::Client) -> Result<(), client::SendRequestError> {
+//! async fn execute_request(client: &Client) -> Result<(), SendRequestError> {
 //!     let res = client
 //!         .get("http://localhost:8080")
 //!         // Add `trace_request` before `send` to any awc request to add instrumentation


### PR DESCRIPTION
actix-web is not re-exporting awc's client module anymore, since
https://github.com/actix/actix-web/commit/871ca5e4ae2bdc22d1ea02701c2992fa8d04aed7
and is  documented here
https://github.com/actix/actix-web/blob/22dcc311937967b9da972b6304cb97d5684d2cae/CHANGES.md

Note that even if the change is on the unreleased section, this change
was released on actix-web = "4.0.0-beta.4".