### PR TITLE
Attach otel ctx synchronously to prevent multiple traces for a single request

### DIFF
--- a/src/middleware/trace.rs
+++ b/src/middleware/trace.rs
@@ -223,6 +223,9 @@ where
         let span = self.tracer.build(builder);
         let cx = Context::current_with_span(span);
         drop(conn_info);
+        // attach synchronously for the sync part of service calls
+        // with_context below attaches for the async part.
+        let _attachment = cx.clone().attach();
 
         let fut = self
             .service


### PR DESCRIPTION
So, I'm not 100% sure that this is the correct way to fix this issue, but it works in my tests.

Here's the issue:

* I have otel, otel_tracing, and actix_web_otel
* When I traced a request, spans I created in my custom middlewares were showing up in totally separate traces.
* When I logged the current span context in these middleware I was getting an empty context, despite the logs from actix_web_otel showing up first.
* I eventually realized that I was creating tracing spans in the synchronous part of the middleware (and attaching those spans using `.instrument(span)` as you should) so I tried adding the sync attachment in this PR, and it worked, I now have one trace per request, with multiple spans inside.

This seems like the correct way of handling it, but otel is kind of complex, so it's possible there's a better way I'm not aware of. I'm also using older versions of all of the dependencies so I don't have to upgrade actix_web, so it's also possible this is fixed in otel somewhere. Feel free to close this PR if there's a better way of handling it or if this is fixed somewhere else.

before:
<img width="1334" alt="Screen Shot 2021-03-15 at 1 20 51 PM" src="https://user-images.githubusercontent.com/950023/111194823-f4dfec80-8591-11eb-9198-e1df5a9b1e74.png">

after:
<img width="1789" alt="Screen Shot 2021-03-15 at 1 20 42 PM" src="https://user-images.githubusercontent.com/950023/111194836-f8737380-8591-11eb-99e1-2e3e79042b65.png">
