### PR TITLE
Support tracing sync middlewares

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 
 [features]
 metrics = ["opentelemetry/metrics", "opentelemetry-prometheus", "prometheus"]
+sync-middleware = []
 
 [dependencies]
 actix-http = { version = "3.0.0-beta.4", default-features = false, features = ["compress"] }

--- a/README.md
+++ b/README.md
@@ -42,3 +42,8 @@ $ firefox http://localhost:16686/
 ```
 
 ![Jaeger UI](trace.png)
+
+### Features
+
+- `metrics` -- enable support for opentelemetry metrics (only traces are enabled by default)
+- `sync-middleware` -- enable tracing on actix-web middlewares that do synchronous work before returning a future. Adds a small amount of overhead to every request.

--- a/src/middleware/trace.rs
+++ b/src/middleware/trace.rs
@@ -220,6 +220,8 @@ where
         builder.attributes = Some(attributes);
         let span = self.tracer.build(builder);
         let cx = Context::current_with_span(span);
+        #[cfg(feature="sync-middleware")]
+        let attachment = cx.clone().attach();
         drop(conn_info);
 
         let fut = self
@@ -247,6 +249,8 @@ where
                 }
             });
 
+        #[cfg(feature="sync-middleware")]
+        drop(attachment);
         Box::pin(async move { fut.await })
     }
 }


### PR DESCRIPTION
I'm making a clean PR from #59 

Add support for tracing sync (or the sync part of) middlwares in a single trace. This is behind a feature flag since it adds some overhead. I added docs for the `metrics` flag as well, just so all flags are documented. Let me know if anything seems off.