### PR TITLE
Update to otel v0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-* Update to otel v0.19
+* Update to otel v0.19 (#126)
 
 ## [v0.13.0](https://github.com/OutThereLabs/actix-web-opentelemetry/compare/v0.13.0-alpha.1..v0.13.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+* Update to otel v0.19
+
 ## [v0.13.0](https://github.com/OutThereLabs/actix-web-opentelemetry/compare/v0.13.0-alpha.1..v0.13.0)
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,16 +21,16 @@ actix-http = { version = "3.0", default-features = false, features = ["compress-
 actix-web = { version = "4.0", default-features = false, features = ["compress-zstd"] }
 awc = { version = "3.0", optional = true, default-features = false, features = ["compress-zstd"] }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
-opentelemetry = { version = "0.18", default-features = false, features = ["trace", "rt-tokio-current-thread"] }
-opentelemetry-prometheus = { version = "0.11", optional = true }
-opentelemetry-semantic-conventions = "0.10"
+opentelemetry = { version = "0.19", default-features = false, features = ["trace", "rt-tokio-current-thread"] }
+opentelemetry-prometheus = { version = "0.12", optional = true }
+opentelemetry-semantic-conventions = "0.11"
 prometheus = { version = "0.13", default-features = false, optional = true }
 serde = "1.0"
 
 [dev-dependencies]
 actix-web = { version = "4.0", features = ["macros"] }
 actix-web-opentelemetry = { path = ".", features = ["metrics-prometheus", "sync-middleware", "awc"] }
-opentelemetry-jaeger = { version = "0.17", features = ["rt-tokio-current-thread"] }
+opentelemetry-jaeger = { version = "0.18", features = ["rt-tokio-current-thread"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -32,7 +32,6 @@ async fn main() -> io::Result<()> {
                 selectors::simple::histogram([1.0, 2.0, 5.0, 10.0, 20.0, 50.0]),
                 aggregation::cumulative_temporality_selector(),
             )
-            .with_memory(true),
         )
         .build();
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -27,12 +27,10 @@ async fn main() -> io::Result<()> {
     // Start a new prometheus metrics pipeline if --features metrics-prometheus is used
     #[cfg(feature = "metrics-prometheus")]
     let metrics_handler = {
-        let controller = controllers::basic(
-            processors::factory(
-                selectors::simple::histogram([1.0, 2.0, 5.0, 10.0, 20.0, 50.0]),
-                aggregation::cumulative_temporality_selector(),
-            )
-        )
+        let controller = controllers::basic(processors::factory(
+            selectors::simple::histogram([1.0, 2.0, 5.0, 10.0, 20.0, 50.0]),
+            aggregation::cumulative_temporality_selector(),
+        ))
         .build();
 
         let exporter = opentelemetry_prometheus::exporter(controller).init();

--- a/src/client.rs
+++ b/src/client.rs
@@ -22,7 +22,7 @@ use opentelemetry::{
 };
 use opentelemetry_semantic_conventions::trace::{
     HTTP_FLAVOR, HTTP_METHOD, HTTP_REQUEST_CONTENT_LENGTH, HTTP_STATUS_CODE, HTTP_URL,
-    HTTP_USER_AGENT, NET_SOCK_PEER_ADDR, NET_PEER_NAME, NET_PEER_PORT,
+    HTTP_USER_AGENT, NET_PEER_NAME, NET_PEER_PORT, NET_SOCK_PEER_ADDR,
 };
 use serde::Serialize;
 use std::fmt::{self, Debug};
@@ -200,7 +200,8 @@ impl InstrumentedClientRequest {
         }
 
         if let Some(peer_addr) = self.request.get_peer_addr() {
-            self.attrs.push(NET_SOCK_PEER_ADDR.string(peer_addr.to_string()));
+            self.attrs
+                .push(NET_SOCK_PEER_ADDR.string(peer_addr.to_string()));
         }
 
         if let Some(peer_port) = self.request.get_uri().port_u16() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -22,7 +22,7 @@ use opentelemetry::{
 };
 use opentelemetry_semantic_conventions::trace::{
     HTTP_FLAVOR, HTTP_METHOD, HTTP_REQUEST_CONTENT_LENGTH, HTTP_STATUS_CODE, HTTP_URL,
-    HTTP_USER_AGENT, NET_PEER_IP, NET_PEER_NAME, NET_PEER_PORT,
+    HTTP_USER_AGENT, NET_SOCK_PEER_ADDR, NET_PEER_NAME, NET_PEER_PORT,
 };
 use serde::Serialize;
 use std::fmt::{self, Debug};
@@ -200,7 +200,7 @@ impl InstrumentedClientRequest {
         }
 
         if let Some(peer_addr) = self.request.get_peer_addr() {
-            self.attrs.push(NET_PEER_IP.string(peer_addr.to_string()));
+            self.attrs.push(NET_SOCK_PEER_ADDR.string(peer_addr.to_string()));
         }
 
         if let Some(peer_port) = self.request.get_uri().port_u16() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,6 @@
 //!             selectors::simple::histogram([1.0, 2.0, 5.0, 10.0, 20.0, 50.0]),
 //!             aggregation::cumulative_temporality_selector(),
 //!         )
-//!         .with_memory(true),
 //!     )
 //!     .build();
 //!     let exporter = opentelemetry_prometheus::exporter(controller).init();

--- a/src/middleware/metrics.rs
+++ b/src/middleware/metrics.rs
@@ -105,7 +105,6 @@ impl RequestMetricsBuilder {
 ///             selectors::simple::histogram([1.0, 2.0, 5.0, 10.0, 20.0, 50.0]),
 ///             aggregation::cumulative_temporality_selector(),
 ///         )
-///         .with_memory(true),
 ///     )
 ///     .build();
 ///     let exporter = opentelemetry_prometheus::exporter(controller).init();

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,10 +6,13 @@ use actix_web::{
 #[cfg(feature = "metrics")]
 use opentelemetry::KeyValue;
 use opentelemetry::{trace::OrderMap, Key, Value};
-use opentelemetry_semantic_conventions::{resource::HOST_NAME, trace::{
-    HTTP_CLIENT_IP, HTTP_FLAVOR, HTTP_METHOD, HTTP_ROUTE, HTTP_SCHEME,
-    HTTP_TARGET, HTTP_USER_AGENT, NET_HOST_NAME, NET_HOST_PORT, NET_SOCK_PEER_ADDR,
-}};
+use opentelemetry_semantic_conventions::{
+    resource::HOST_NAME,
+    trace::{
+        HTTP_CLIENT_IP, HTTP_FLAVOR, HTTP_METHOD, HTTP_ROUTE, HTTP_SCHEME, HTTP_TARGET,
+        HTTP_USER_AGENT, NET_HOST_NAME, NET_HOST_PORT, NET_SOCK_PEER_ADDR,
+    },
+};
 #[cfg(feature = "awc")]
 use std::fmt::Write;
 


### PR DESCRIPTION
I didn't see a great CHANGELOG for the sem cov changes but found the suggested replacements in the Java code:

https://github.com/open-telemetry/opentelemetry-java/blob/7b8608591e1737ea0727d2373ddd813bc18cdaaa/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/SemanticAttributes.java#L2008

HTTP_HOST -> NET_HOST_NAME
HTTP_SERVER_NAME -> NET_HOST_NAME
NET_PEER_IP -> NET_SOCK_PEER_ADDR