### PR TITLE
Remove active request units until bug is resolved

### DIFF
--- a/src/middleware/metrics.rs
+++ b/src/middleware/metrics.rs
@@ -46,7 +46,6 @@ impl Metrics {
             .with_description(
                 "Measures the number of concurrent HTTP requests that are currently in-flight.",
             )
-            .with_unit(Unit::new("{request}"))
             .init();
 
         let http_server_request_size = meter


### PR DESCRIPTION
This will result in promethus names like `http_server_active_requests_{request}` currently due to an upstream bug.