### PR TITLE
Fix typo for http_server_response_size metric

### DIFF
--- a/src/middleware/metrics.rs
+++ b/src/middleware/metrics.rs
@@ -58,7 +58,7 @@ impl Metrics {
 
         let http_server_response_size = meter
             .u64_histogram(HTTP_SERVER_RESPONSE_SIZE)
-            .with_description("Measures the size of HTTP request messages (compressed).")
+            .with_description("Measures the size of HTTP response messages (compressed).")
             .with_unit(Unit::new("By"))
             .init();
 


### PR DESCRIPTION
Noticed that this seemed to be wrong. Probably just a copy-paste typo:

![image](https://github.com/OutThereLabs/actix-web-opentelemetry/assets/1657142/f5076832-fb0a-4b38-981a-7d97d4a98954)
