### PR TITLE
Update to otel v0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,18 +21,18 @@ actix-http = { version = "3.0", default-features = false, features = ["compress-
 actix-web = { version = "4.0", default-features = false, features = ["compress-zstd"] }
 awc = { version = "3.0", optional = true, default-features = false, features = ["compress-zstd"] }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
-opentelemetry = { version = "0.22", default-features = false, features = ["trace"] }
-opentelemetry-prometheus = { version = "0.15", optional = true }
-opentelemetry-semantic-conventions = "0.14"
+opentelemetry = { version = "0.23", default-features = false, features = ["trace"] }
+opentelemetry-prometheus = { version = "0.16", optional = true }
+opentelemetry-semantic-conventions = "0.15"
 prometheus = { version = "0.13", default-features = false, optional = true }
 serde = "1.0"
 
 [dev-dependencies]
 actix-web = { version = "4.0", features = ["macros"] }
 actix-web-opentelemetry = { path = ".", features = ["metrics-prometheus", "sync-middleware", "awc"] }
-opentelemetry_sdk = { version = "0.22", features = ["metrics", "rt-tokio-current-thread"] }
-opentelemetry-jaeger = { version = "0.21", features = ["rt-tokio-current-thread"] }
-opentelemetry-stdout = { version = "0.3", features = ["trace", "metrics"] }
+opentelemetry_sdk = { version = "0.23", features = ["metrics", "rt-tokio-current-thread"] }
+opentelemetry-otlp = "0.16"
+opentelemetry-stdout = { version = "0.4", features = ["trace", "metrics"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/client.rs
+++ b/src/client.rs
@@ -165,12 +165,11 @@ impl InstrumentedClientRequest {
         F: FnOnce(ClientRequest) -> R,
         R: Future<Output = AwcResult>,
     {
-        let tracer = global::tracer_provider().versioned_tracer(
-            "actix-web-opentelemetry",
-            Some(env!("CARGO_PKG_VERSION")),
-            Some(opentelemetry_semantic_conventions::SCHEMA_URL),
-            None,
-        );
+        let tracer = global::tracer_provider().tracer_builder("actix-web-opentelemetry")
+            .with_version(env!("CARGO_PKG_VERSION"))
+            .with_schema_url(opentelemetry_semantic_conventions::SCHEMA_URL)
+            .build();
+
         // Client attributes
         // https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/http/http-spans.md#http-client
         self.attrs.extend(

--- a/src/middleware/trace.rs
+++ b/src/middleware/trace.rs
@@ -121,12 +121,10 @@ where
 
     fn new_transform(&self, service: S) -> Self::Future {
         ok(RequestTracingMiddleware::new(
-            global::tracer_provider().versioned_tracer(
-                "actix-web-opentelemetry",
-                Some(env!("CARGO_PKG_VERSION")),
-                Some(opentelemetry_semantic_conventions::SCHEMA_URL),
-                None,
-            ),
+            global::tracer_provider().tracer_builder("actix-web-opentelemetry")
+                .with_version(env!("CARGO_PKG_VERSION"))
+                .with_schema_url(opentelemetry_semantic_conventions::SCHEMA_URL)
+                .build(),
             service,
             self.route_formatter.clone(),
         ))

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,7 @@ use actix_web::{
 };
 use opentelemetry::{KeyValue, Value};
 use opentelemetry_semantic_conventions::trace::{
-    CLIENT_ADDRESS, CLIENT_SOCKET_ADDRESS, HTTP_REQUEST_BODY_SIZE, HTTP_REQUEST_METHOD, HTTP_ROUTE,
+    CLIENT_ADDRESS, NETWORK_PEER_ADDRESS, HTTP_REQUEST_BODY_SIZE, HTTP_REQUEST_METHOD, HTTP_ROUTE,
     NETWORK_PROTOCOL_VERSION, SERVER_ADDRESS, SERVER_PORT, URL_PATH, URL_QUERY, URL_SCHEME,
     USER_AGENT_ORIGINAL,
 };
@@ -85,7 +85,7 @@ pub(super) fn trace_attributes_from_request(
     if let Some(peer_addr) = req.peer_addr().map(|socket| socket.ip().to_string()) {
         if Some(peer_addr.as_str()) != remote_addr {
             // Client is going through a proxy
-            attributes.push(KeyValue::new(CLIENT_SOCKET_ADDRESS, peer_addr));
+            attributes.push(KeyValue::new(NETWORK_PEER_ADDRESS, peer_addr));
         }
     }
     let mut host_parts = conn_info.host().split_terminator(':');


### PR DESCRIPTION
Update to otel v0.23 and switch to `opentelemetry-otlp` as `opentelemetry-jaeger` is now deprecated.