### PR TITLE
Update opentelemetry packages to 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,18 +21,18 @@ actix-http = { version = "3.0", default-features = false, features = ["compress-
 actix-web = { version = "4.0", default-features = false, features = ["compress-zstd"] }
 awc = { version = "3.0", optional = true, default-features = false, features = ["compress-zstd"] }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
-opentelemetry = { version = "0.23", default-features = false, features = ["trace"] }
-opentelemetry-prometheus = { version = "0.16", optional = true }
-opentelemetry-semantic-conventions = "0.15"
+opentelemetry = { version = "0.24", default-features = false, features = ["trace"] }
+opentelemetry-prometheus = { version = "0.17", optional = true }
+opentelemetry-semantic-conventions = "0.16"
 prometheus = { version = "0.13", default-features = false, optional = true }
 serde = "1.0"
 
 [dev-dependencies]
 actix-web = { version = "4.0", features = ["macros"] }
 actix-web-opentelemetry = { path = ".", features = ["metrics-prometheus", "sync-middleware", "awc"] }
-opentelemetry_sdk = { version = "0.23", features = ["metrics", "rt-tokio-current-thread"] }
-opentelemetry-otlp = "0.16"
-opentelemetry-stdout = { version = "0.4", features = ["trace", "metrics"] }
+opentelemetry_sdk = { version = "0.24", features = ["metrics", "rt-tokio-current-thread"] }
+opentelemetry-otlp = "0.17"
+opentelemetry-stdout = { version = "0.5", features = ["trace", "metrics"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/client.rs
+++ b/src/client.rs
@@ -21,7 +21,7 @@ use opentelemetry::{
     Context, KeyValue,
 };
 use opentelemetry_semantic_conventions::trace::{
-    HTTP_REQUEST_BODY_SIZE, HTTP_REQUEST_METHOD, HTTP_RESPONSE_STATUS_CODE, SERVER_ADDRESS,
+    MESSAGING_MESSAGE_BODY_SIZE, HTTP_REQUEST_METHOD, HTTP_RESPONSE_STATUS_CODE, SERVER_ADDRESS,
     SERVER_PORT, URL_FULL, USER_AGENT_ORIGINAL,
 };
 use serde::Serialize;
@@ -214,7 +214,7 @@ impl InstrumentedClientRequest {
                 .and_then(|str_len| str_len.parse::<i64>().ok())
         }) {
             self.attrs
-                .push(KeyValue::new(HTTP_REQUEST_BODY_SIZE, content_length))
+                .push(KeyValue::new(MESSAGING_MESSAGE_BODY_SIZE, content_length))
         }
 
         let span = tracer

--- a/src/middleware/metrics.rs
+++ b/src/middleware/metrics.rs
@@ -8,7 +8,7 @@ use actix_web::dev;
 use futures_util::future::{self, FutureExt as _, LocalBoxFuture};
 use opentelemetry::{
     global,
-    metrics::{Histogram, Meter, MeterProvider, Unit, UpDownCounter},
+    metrics::{Histogram, Meter, MeterProvider, UpDownCounter},
     KeyValue,
 };
 use std::borrow::Cow;
@@ -44,7 +44,7 @@ impl Metrics {
         let http_server_duration = meter
             .f64_histogram(HTTP_SERVER_DURATION)
             .with_description("Measures the duration of inbound HTTP requests.")
-            .with_unit(Unit::new("s"))
+            .with_unit("s")
             .init();
 
         let http_server_active_requests = meter
@@ -57,13 +57,13 @@ impl Metrics {
         let http_server_request_size = meter
             .u64_histogram(HTTP_SERVER_REQUEST_SIZE)
             .with_description("Measures the size of HTTP request messages (compressed).")
-            .with_unit(Unit::new("By"))
+            .with_unit("By")
             .init();
 
         let http_server_response_size = meter
             .u64_histogram(HTTP_SERVER_RESPONSE_SIZE)
             .with_description("Measures the size of HTTP response messages (compressed).")
-            .with_unit(Unit::new("By"))
+            .with_unit("By")
             .init();
 
         Metrics {

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,7 @@ use actix_web::{
 };
 use opentelemetry::{KeyValue, Value};
 use opentelemetry_semantic_conventions::trace::{
-    CLIENT_ADDRESS, NETWORK_PEER_ADDRESS, HTTP_REQUEST_BODY_SIZE, HTTP_REQUEST_METHOD, HTTP_ROUTE,
+    CLIENT_ADDRESS, NETWORK_PEER_ADDRESS, MESSAGING_MESSAGE_BODY_SIZE, HTTP_REQUEST_METHOD, HTTP_ROUTE,
     NETWORK_PROTOCOL_VERSION, SERVER_ADDRESS, SERVER_PORT, URL_PATH, URL_QUERY, URL_SCHEME,
     USER_AGENT_ORIGINAL,
 };
@@ -124,7 +124,7 @@ pub(super) fn trace_attributes_from_request(
         .and_then(|len| len.to_str().ok().and_then(|s| s.parse::<i64>().ok()))
         .filter(|&len| len > 0)
     {
-        attributes.push(KeyValue::new(HTTP_REQUEST_BODY_SIZE, content_length));
+        attributes.push(KeyValue::new(MESSAGING_MESSAGE_BODY_SIZE, content_length));
     }
 
     if let Some(user_agent) = req


### PR DESCRIPTION
Could not fully upgrade to 0.25 because of `opentelemetry-prometheus` not being up-to-date but this is the next best thing.