### PR TITLE
add RequestMetricsBuilder.with_metric_attrs_from_req

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@
 #[cfg(feature = "awc")]
 mod client;
 mod middleware;
-pub(crate) mod util;
+mod util;
 
 #[cfg(feature = "awc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "awc")))]
@@ -159,6 +159,11 @@ pub use middleware::metrics::prometheus::PrometheusMetricsHandler;
 #[cfg(feature = "metrics")]
 #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
 pub use middleware::metrics::{RequestMetrics, RequestMetricsBuilder, RequestMetricsMiddleware};
+#[cfg(feature = "metrics")]
+#[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
+pub use util::metrics_attributes_from_request;
+
+
 pub use {
     middleware::route_formatter::RouteFormatter,
     middleware::trace::{RequestTracing, RequestTracingMiddleware},

--- a/src/middleware/metrics.rs
+++ b/src/middleware/metrics.rs
@@ -80,6 +80,7 @@ impl Metrics {
 pub struct RequestMetricsBuilder {
     route_formatter: Option<Arc<dyn RouteFormatter + Send + Sync + 'static>>,
     meter: Option<Meter>,
+    metric_attrs_from_req: Option<fn(&dev::ServiceRequest, Cow<'static, str>) -> Vec<KeyValue>>
 }
 
 impl RequestMetricsBuilder {
@@ -103,6 +104,12 @@ impl RequestMetricsBuilder {
         self
     }
 
+    /// Set a metric attrs function that the middleware will use to create metric attributes
+    pub fn with_metric_attrs_from_req(mut self, metric_attrs_from_req: fn(&dev::ServiceRequest, Cow<'static, str>) -> Vec<KeyValue>) -> Self {
+        self.metric_attrs_from_req = Some(metric_attrs_from_req);
+        self
+    }
+
     /// Build the `RequestMetrics` middleware
     pub fn build(self) -> RequestMetrics {
         let meter = self
@@ -112,6 +119,7 @@ impl RequestMetricsBuilder {
         RequestMetrics {
             route_formatter: self.route_formatter,
             metrics: Arc::new(Metrics::new(meter)),
+            metric_attrs_from_req: self.metric_attrs_from_req.unwrap_or(metrics_attributes_from_request)
         }
     }
 }
@@ -168,6 +176,7 @@ fn get_versioned_meter(meter_provider: impl MeterProvider) -> Meter {
 pub struct RequestMetrics {
     route_formatter: Option<Arc<dyn RouteFormatter + Send + Sync + 'static>>,
     metrics: Arc<Metrics>,
+    metric_attrs_from_req: fn(&dev::ServiceRequest, Cow<'static, str>) -> Vec<KeyValue>
 }
 
 impl RequestMetrics {
@@ -204,6 +213,7 @@ where
             service,
             metrics: self.metrics.clone(),
             route_formatter: self.route_formatter.clone(),
+            metric_attrs_from_req: self.metric_attrs_from_req.clone()
         };
 
         future::ok(service)
@@ -216,6 +226,7 @@ pub struct RequestMetricsMiddleware<S> {
     service: S,
     metrics: Arc<Metrics>,
     route_formatter: Option<Arc<dyn RouteFormatter + Send + Sync + 'static>>,
+    metric_attrs_from_req: fn(&dev::ServiceRequest, Cow<'static, str>) -> Vec<KeyValue>
 }
 
 impl<S, B> dev::Service<dev::ServiceRequest> for RequestMetricsMiddleware<S>
@@ -246,7 +257,7 @@ where
             http_target = Cow::Owned(formatter.format(&http_target));
         }
 
-        let mut attributes = metrics_attributes_from_request(&req, http_target);
+        let mut attributes = (self.metric_attrs_from_req)(&req, http_target);
         self.metrics.http_server_active_requests.add(1, &attributes);
 
         let content_length = req

--- a/src/util.rs
+++ b/src/util.rs
@@ -138,8 +138,9 @@ pub(super) fn trace_attributes_from_request(
     attributes
 }
 
+/// Create metric attributes for the given request
 #[cfg(feature = "metrics")]
-pub(super) fn metrics_attributes_from_request(
+pub fn metrics_attributes_from_request(
     req: &ServiceRequest,
     http_route: std::borrow::Cow<'static, str>,
 ) -> Vec<KeyValue> {


### PR DESCRIPTION
Adding a builder method `with_metric_attrs_from_req` that accepts a function to generate metric attributes from the request. Function has the same signature with and by default is `util::metrics_attributes_from_request`. Also exposing `metrics_attributes_from_request` since whoever wants to add additional attributes may want to reuse it and extend its result.

Fixes #171 