### PR TITLE
Upgrade to opentelemetry-rust 0.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.22.0](https://github.com/OutThereLabs/actix-web-opentelemetry/compare/v0.22.0..v0.21.0)
+
+### Changed
+
+* Update opentelemetry packages to 0.29 (#192)
+
 ## [v0.21.0](https://github.com/OutThereLabs/actix-web-opentelemetry/compare/v0.21.0..v0.20.1)
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-opentelemetry"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Julian Tescher <julian@outtherelabs.com>"]
 description = "OpenTelemetry integration for Actix Web apps"
 homepage = "https://github.com/OutThereLabs/actix-web-opentelemetry"
@@ -35,14 +35,14 @@ awc = { version = "3.0", optional = true, default-features = false, features = [
 futures-util = { version = "0.3", default-features = false, features = [
   "alloc",
 ] }
-opentelemetry = { version = "0.28", default-features = false, features = [
+opentelemetry = { version = "0.29", default-features = false, features = [
   "trace",
 ] }
-opentelemetry-prometheus = { version = "0.28", optional = true }
-opentelemetry-semantic-conventions = { version = "0.28", features = [
+opentelemetry-prometheus = { version = "0.29", optional = true }
+opentelemetry-semantic-conventions = { version = "0.29", features = [
   "semconv_experimental",
 ] }
-opentelemetry_sdk = { version = "0.28", optional = true, features = [
+opentelemetry_sdk = { version = "0.29", optional = true, features = [
   "metrics",
   "rt-tokio-current-thread",
 ] }
@@ -57,13 +57,13 @@ actix-web-opentelemetry = { path = ".", features = [
   "sync-middleware",
   "awc",
 ] }
-opentelemetry_sdk = { version = "0.28", features = [
+opentelemetry_sdk = { version = "0.29", features = [
   "spec_unstable_metrics_views",
   "metrics",
   "rt-tokio-current-thread",
 ] }
-opentelemetry-otlp = { version = "0.28", features = ["grpc-tonic"] }
-opentelemetry-stdout = { version = "0.28", features = ["trace", "metrics"] }
+opentelemetry-otlp = { version = "0.29", features = ["grpc-tonic"] }
+opentelemetry-stdout = { version = "0.29", features = ["trace", "metrics"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/client.rs
+++ b/src/client.rs
@@ -23,9 +23,12 @@ use opentelemetry::{
     trace::{SpanKind, Status, TraceContextExt, Tracer},
     Context, KeyValue,
 };
-use opentelemetry_semantic_conventions::trace::{
-    HTTP_REQUEST_METHOD, HTTP_RESPONSE_STATUS_CODE, MESSAGING_MESSAGE_BODY_SIZE, SERVER_ADDRESS,
-    SERVER_PORT, URL_FULL, USER_AGENT_ORIGINAL,
+use opentelemetry_semantic_conventions::{
+    attribute::MESSAGING_MESSAGE_BODY_SIZE,
+    trace::{
+        HTTP_REQUEST_METHOD, HTTP_RESPONSE_STATUS_CODE, SERVER_ADDRESS, SERVER_PORT, URL_FULL,
+        USER_AGENT_ORIGINAL,
+    },
 };
 use serde::Serialize;
 use std::mem;

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,11 +4,11 @@ use actix_web::{
     http::{Method, Version},
 };
 use opentelemetry::{KeyValue, Value};
-use opentelemetry_semantic_conventions::trace::{
-    CLIENT_ADDRESS, NETWORK_PEER_ADDRESS, MESSAGING_MESSAGE_BODY_SIZE, HTTP_REQUEST_METHOD, HTTP_ROUTE,
+use opentelemetry_semantic_conventions::{attribute::MESSAGING_MESSAGE_BODY_SIZE, trace::{
+    CLIENT_ADDRESS, HTTP_REQUEST_METHOD, HTTP_ROUTE, NETWORK_PEER_ADDRESS,
     NETWORK_PROTOCOL_VERSION, SERVER_ADDRESS, SERVER_PORT, URL_PATH, URL_QUERY, URL_SCHEME,
     USER_AGENT_ORIGINAL,
-};
+}};
 
 #[cfg(feature = "awc")]
 #[inline]


### PR DESCRIPTION
Hi, this PR should update all of the otel packages to the latest 0.29 and fix the breaking changes.

This is pending my PR here: https://github.com/open-telemetry/opentelemetry-rust/pull/2851

Thanks!