### PR TITLE
Updating dependencies, updating location of MESSAGING_MESSAGE_BODY_SIZE

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,18 +35,18 @@ awc = { version = "3.0", optional = true, default-features = false, features = [
 futures-util = { version = "0.3", default-features = false, features = [
   "alloc",
 ] }
-opentelemetry = { version = "0.28", default-features = false, features = [
+opentelemetry = { version = "0.29", default-features = false, features = [
   "trace",
 ] }
-opentelemetry-prometheus = { version = "0.28", optional = true }
-opentelemetry-semantic-conventions = { version = "0.28", features = [
+opentelemetry-prometheus = { version = "0.29", optional = true }
+opentelemetry-semantic-conventions = { version = "0.29", features = [
   "semconv_experimental",
 ] }
-opentelemetry_sdk = { version = "0.28", optional = true, features = [
+opentelemetry_sdk = { version = "0.29", optional = true, features = [
   "metrics",
   "rt-tokio-current-thread",
 ] }
-prometheus = { version = "0.13", default-features = false, optional = true }
+prometheus = { version = "0.14", default-features = false, optional = true }
 serde = "1.0"
 tracing = { version = "0.1.41", optional = true }
 
@@ -57,13 +57,13 @@ actix-web-opentelemetry = { path = ".", features = [
   "sync-middleware",
   "awc",
 ] }
-opentelemetry_sdk = { version = "0.28", features = [
+opentelemetry_sdk = { version = "0.29", features = [
   "spec_unstable_metrics_views",
   "metrics",
   "rt-tokio-current-thread",
 ] }
-opentelemetry-otlp = { version = "0.28", features = ["grpc-tonic"] }
-opentelemetry-stdout = { version = "0.28", features = ["trace", "metrics"] }
+opentelemetry-otlp = { version = "0.29", features = ["grpc-tonic"] }
+opentelemetry-stdout = { version = "0.29", features = ["trace", "metrics"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/client.rs
+++ b/src/client.rs
@@ -24,9 +24,10 @@ use opentelemetry::{
     Context, KeyValue,
 };
 use opentelemetry_semantic_conventions::trace::{
-    HTTP_REQUEST_METHOD, HTTP_RESPONSE_STATUS_CODE, MESSAGING_MESSAGE_BODY_SIZE, SERVER_ADDRESS,
+    HTTP_REQUEST_METHOD, HTTP_RESPONSE_STATUS_CODE, SERVER_ADDRESS,
     SERVER_PORT, URL_FULL, USER_AGENT_ORIGINAL,
 };
+use opentelemetry_semantic_conventions::attribute::MESSAGING_MESSAGE_BODY_SIZE;
 use serde::Serialize;
 use std::mem;
 use std::str::FromStr;

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,10 +5,11 @@ use actix_web::{
 };
 use opentelemetry::{KeyValue, Value};
 use opentelemetry_semantic_conventions::trace::{
-    CLIENT_ADDRESS, NETWORK_PEER_ADDRESS, MESSAGING_MESSAGE_BODY_SIZE, HTTP_REQUEST_METHOD, HTTP_ROUTE,
+    CLIENT_ADDRESS, NETWORK_PEER_ADDRESS, HTTP_REQUEST_METHOD, HTTP_ROUTE,
     NETWORK_PROTOCOL_VERSION, SERVER_ADDRESS, SERVER_PORT, URL_PATH, URL_QUERY, URL_SCHEME,
     USER_AGENT_ORIGINAL,
 };
+use opentelemetry_semantic_conventions::attribute::MESSAGING_MESSAGE_BODY_SIZE;
 
 #[cfg(feature = "awc")]
 #[inline]


### PR DESCRIPTION
Should allow CI to pass 🤞 

Updated dependencies to most recent version and updated the location of `MESSAGING_MESSAGE_BODY_SIZE` which had been moved from the trace to the attribute file.

Breaking change was introduced to otel in this commit: https://github.com/open-telemetry/opentelemetry-rust/commit/597327f1996e78a7fecf38b1a095fd6240190ef9

Tagging maintainer @jtescher